### PR TITLE
Fix casing

### DIFF
--- a/ADC121C_MQ131.py
+++ b/ADC121C_MQ131.py
@@ -96,7 +96,7 @@ class ADC121C_MQ131():
 		return {'o3' : ppm}
 
 from ADC121C_MQ131 import ADC121C_MQ131
-ADC121C_mq131 = ADC121C_MQ131()
+adc121c_mq131 = ADC121C_MQ131()
 
 while True :
 	adc121c_mq131.data_config()

--- a/ADC121C_MQ135.py
+++ b/ADC121C_MQ135.py
@@ -104,7 +104,7 @@ class ADC121C_MQ135():
         return {'nh3' : ppm}
 
 from ADC121C_MQ135 import ADC121C_MQ135
-ADC121C_mq135 = ADC121C_MQ135()
+adc121c_mq135 = ADC121C_MQ135()
 
 while True :
 	adc121c_mq135.data_config()


### PR DESCRIPTION
Casing incorrect for instance variables in MQ131 / MQ135 modules.